### PR TITLE
Change eventId to cmdId for the command POSTs

### DIFF
--- a/services/IoT/applications/api.md
+++ b/services/IoT/applications/api.md
@@ -63,11 +63,11 @@ In addition to using the MQTT messaging protocol, you can also configure your ap
 {: codeblock}
 
 ### Non-secure command POST request
-<pre class="pre">http://<var class="keyword varname">orgId</var>.messaging.internetofthings.ibmcloud.com:1883/api/v0002/application/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/commands/<var class="keyword varname">eventId</var></pre>
+<pre class="pre">http://<var class="keyword varname">orgId</var>.messaging.internetofthings.ibmcloud.com:1883/api/v0002/application/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/commands/<var class="keyword varname">cmdId</var></pre>
 {: codeblock}
 
 ### Secure command POST request
-<pre class="pre">https://<var class="keyword varname">orgId</var>.messaging.internetofthings.ibmcloud.com:8883/api/v0002/application/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/commands/<var class="keyword varname">eventId</var></pre>
+<pre class="pre">https://<var class="keyword varname">orgId</var>.messaging.internetofthings.ibmcloud.com:8883/api/v0002/application/types/<var class="keyword varname">typeId</var>/devices/<var class="keyword varname">deviceId</var>/commands/<var class="keyword varname">cmdId</var></pre>
 {: codeblock}
 
 If you are connecting a device or application to the Quickstart service, replace **orgId** with the string 'quickstart'.


### PR DESCRIPTION
Follow up action from https://developer.ibm.com/answers/questions/342839/url-format-for-sending-commands-over-http-to-watso.html